### PR TITLE
Add support for Wagtail running in a subdirectory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,7 @@ The following settings are available (Set via your Django settings):
     - ``WAGTAIL_2FA_REQUIRED`` (default ``False``): When set to True all
       staff, superuser and other users with access to the Wagtail Admin site
       are forced to login using two factor authentication.
+    - ``WAGTAIL_MOUNT_PATH``: The uWSGI mount point that Wagtail is running at. Ex. ``/wagtail``
 
 
 Sandbox

--- a/src/wagtail_2fa/__init__.py
+++ b/src/wagtail_2fa/__init__.py
@@ -1,3 +1,3 @@
 default_app_config = 'wagtail_2fa.apps.Wagtail2faConfig'
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'

--- a/src/wagtail_2fa/__init__.py
+++ b/src/wagtail_2fa/__init__.py
@@ -1,3 +1,3 @@
 default_app_config = 'wagtail_2fa.apps.Wagtail2faConfig'
 
-__version__ = '1.1.0'
+__version__ = '1.0.0'

--- a/src/wagtail_2fa/apps.py
+++ b/src/wagtail_2fa/apps.py
@@ -16,3 +16,6 @@ class Wagtail2faConfig(AppConfig):
 
         if not hasattr(settings, 'WAGTAIL_2FA_REQUIRED'):
             settings.WAGTAIL_2FA_REQUIRED = False
+
+        if not hasattr(settings, 'WAGTAIL_MOUNT_PATH'):
+            settings.WAGTAIL_MOUNT_PATH = ''

--- a/src/wagtail_2fa/middleware.py
+++ b/src/wagtail_2fa/middleware.py
@@ -17,7 +17,7 @@ class VerifyUserMiddleware(_OTPMiddleware):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._allowed_paths = [reverse(n) for n in self._allowed_url_names]
+        self._allowed_paths = [settings.WAGTAIL_MOUNT_PATH + reverse(n) for n in self._allowed_url_names]
 
     def process_request(self, request):
         super().process_request(request)

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -1,0 +1,12 @@
+from django.apps import apps
+
+
+def test_sets_default_wagtail_mount_path(settings):
+    # WAGTAIL_MOUNT_PATH was already populated in the test environment
+    # Explicitly deleting it to ensure it's added when ready() is called
+    delattr(settings, 'WAGTAIL_MOUNT_PATH')
+    assert not hasattr(settings, 'WAGTAIL_MOUNT_PATH')
+    app_config = apps.get_app_config('wagtail_2fa')
+    app_config.ready()
+
+    assert settings.WAGTAIL_MOUNT_PATH == ''

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -1,6 +1,17 @@
 from django.apps import apps
 
 
+def test_sets_default_wagtail_2fa_required(settings):
+    # WAGTAIL_2FA_REQUIRED was already populated in the test environment
+    # Explicitly deleting it to ensure it's added when ready() is called
+    delattr(settings, 'WAGTAIL_2FA_REQUIRED')
+    assert not hasattr(settings, 'WAGTAIL_2FA_REQUIRED')
+    app_config = apps.get_app_config('wagtail_2fa')
+    app_config.ready()
+
+    assert not settings.WAGTAIL_2FA_REQUIRED
+    
+
 def test_sets_default_wagtail_mount_path(settings):
     # WAGTAIL_MOUNT_PATH was already populated in the test environment
     # Explicitly deleting it to ensure it's added when ready() is called

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -51,10 +51,10 @@ def test_not_specifiying_wagtail_mount_point_does_not_prepend_allowed_paths_with
     allowed_paths = VerifyUserMiddleware()._allowed_paths
 
     for allowed_path in allowed_paths:
-        assert allowed_path.startswith('/admin')
+        assert allowed_path.startswith('/cms')
 
 
-def test_specifiying_wagtail_mount_point_does_prepend_allowed_paths_with_wagtail_mount_point():
+def test_specifiying_wagtail_mount_point_does_prepend_allowed_paths_with_wagtail_mount_point(rf, superuser, settings):
     settings.WAGTAIL_MOUNT_POINT = '/wagtail'
     allowed_paths = VerifyUserMiddleware()._allowed_paths
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -47,16 +47,17 @@ def test_superuser_dont_require_register_device(rf, superuser, settings):
     assert response is None
 
 
-def test_not_specifiying_wagtail_mount_point_does_not_prepend_allowed_paths_with_wagtail_mount_point():
+def test_not_specifiying_wagtail_mount_point_does_not_prepend_allowed_paths_with_wagtail_mount_path(settings):
+    settings.WAGTAIL_MOUNT_PATH = ''
     allowed_paths = VerifyUserMiddleware()._allowed_paths
 
     for allowed_path in allowed_paths:
         assert allowed_path.startswith('/cms')
 
 
-def test_specifiying_wagtail_mount_point_does_prepend_allowed_paths_with_wagtail_mount_point(rf, superuser, settings):
-    settings.WAGTAIL_MOUNT_POINT = '/wagtail'
+def test_specifiying_wagtail_mount_point_does_prepend_allowed_paths_with_wagtail_mount_path(settings):
+    settings.WAGTAIL_MOUNT_PATH = '/wagtail'
     allowed_paths = VerifyUserMiddleware()._allowed_paths
 
     for allowed_path in allowed_paths:
-        assert allowed_path.startswith(settings.WAGTAIL_MOUNT_POINT)
+        assert allowed_path.startswith(settings.WAGTAIL_MOUNT_PATH)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -45,3 +45,18 @@ def test_superuser_dont_require_register_device(rf, superuser, settings):
     middleware = VerifyUserMiddleware()
     response = middleware.process_request(request)
     assert response is None
+
+
+def test_not_specifiying_wagtail_mount_point_does_not_prepend_allowed_paths_with_wagtail_mount_point():
+    allowed_paths = VerifyUserMiddleware()._allowed_paths
+
+    for allowed_path in allowed_paths:
+        assert allowed_path.startswith('/admin')
+
+
+def test_specifiying_wagtail_mount_point_does_prepend_allowed_paths_with_wagtail_mount_point():
+    settings.WAGTAIL_MOUNT_POINT = '/wagtail'
+    allowed_paths = VerifyUserMiddleware()._allowed_paths
+
+    for allowed_path in allowed_paths:
+        assert allowed_path.startswith(settings.WAGTAIL_MOUNT_POINT)


### PR DESCRIPTION
When Wagtail is mounted in a subdirectory, 2FA through `VerifyUserMiddleware` does not work.

Because`_allowed_paths` defined internally to the middleware do not include the subdirectory the application is running in, navigation to the redirected paths required for 2FA result in a redirect loop.

This change exposes an optional setting to specify the subdirectory that Wagtail is mounted in.  If this setting is not defined it assumes that Wagtail is mounted at root, to maintain backward compatibility.

For example, someone may have a uWSGI `mount` configuration of `mount=/wagtail...`.  They can specify `settings.WAGTAIL_MOUNT_PATH = '/wagtail'` to support this configuration. 