### PR TITLE
Add WAGTAIL_2FA_OTP_TOTP_NAME for easier identification the site

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,13 @@ The following settings are available (Set via your Django settings):
     - ``WAGTAIL_2FA_REQUIRED`` (default ``False``): When set to True all
       staff, superuser and other users with access to the Wagtail Admin site
       are forced to login using two factor authentication.
-    - ``WAGTAIL_MOUNT_PATH``: The uWSGI mount point that Wagtail is running at. Ex. ``/wagtail``
+    - ``WAGTAIL_MOUNT_PATH`` (default: ``''``): The uWSGI mount point that
+      Wagtail is running at. Ex. ``/wagtail``
+    - ``WAGTAIL_2FA_OTP_TOTP_NAME`` (default: ``False``): The issuer name to
+      identify which site is which in your authenticator app. If not set and
+      ``WAGTAIL_SITE_NAME`` is defined it uses this. sets ``OTP_TOTP_ISSUER``
+      under the hood.
+
 
 
 Sandbox

--- a/src/wagtail_2fa/apps.py
+++ b/src/wagtail_2fa/apps.py
@@ -2,6 +2,12 @@ from django.apps import AppConfig
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
+WAGTAIL_2FA_DEFAULT_SETTINGS = {
+    'WAGTAIL_2FA_REQUIRED': False,
+    'WAGTAIL_2FA_OTP_TOTP_NAME': False,
+    'WAGTAIL_MOUNT_PATH': '',
+}
+
 
 class Wagtail2faConfig(AppConfig):
     name = 'wagtail_2fa'
@@ -14,8 +20,17 @@ class Wagtail2faConfig(AppConfig):
                 "Please add 'wagtail_2fa.middleware.VerifyUserMiddleware' "
                 "to django.conf.settings.MIDDLEWARE")
 
-        if not hasattr(settings, 'WAGTAIL_2FA_REQUIRED'):
-            settings.WAGTAIL_2FA_REQUIRED = False
+        for setting_name, setting_default_value in WAGTAIL_2FA_DEFAULT_SETTINGS.items():
+            if not hasattr(settings, setting_name):
+                setattr(settings, setting_name, setting_default_value)
 
-        if not hasattr(settings, 'WAGTAIL_MOUNT_PATH'):
-            settings.WAGTAIL_MOUNT_PATH = ''
+        # Set OTP_TOTP_ISSUER, to identify the app, in authenticator
+        # only set this if it's not already set
+        if not hasattr(settings, 'OTP_TOTP_ISSUER'):
+            if (
+                not settings.WAGTAIL_2FA_OTP_TOTP_NAME
+                and hasattr(settings, 'WAGTAIL_SITE_NAME')
+            ):
+                settings.OTP_TOTP_ISSUER =  settings.WAGTAIL_SITE_NAME
+            elif settings.WAGTAIL_2FA_OTP_TOTP_NAME:
+                settings.OTP_TOTP_ISSUER = settings.WAGTAIL_2FA_OTP_TOTP_NAME

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -1,23 +1,33 @@
+import pytest
 from django.apps import apps
 
+from wagtail_2fa.apps import WAGTAIL_2FA_DEFAULT_SETTINGS
 
-def test_sets_default_wagtail_2fa_required(settings):
-    # WAGTAIL_2FA_REQUIRED was already populated in the test environment
-    # Explicitly deleting it to ensure it's added when ready() is called
-    delattr(settings, 'WAGTAIL_2FA_REQUIRED')
-    assert not hasattr(settings, 'WAGTAIL_2FA_REQUIRED')
+
+@pytest.mark.parametrize("setting_name,expected_value", [
+    ('WAGTAIL_2FA_REQUIRED', False),
+    ('WAGTAIL_2FA_OTP_TOTP_NAME', False),
+    ('WAGTAIL_MOUNT_PATH', ''),
+])
+def test_setting_default_values(setting_name, expected_value, settings):
+    # Explicitly deleting settings to ensure it's added when ready() is called
+    delattr(settings, setting_name)
+
     app_config = apps.get_app_config('wagtail_2fa')
     app_config.ready()
 
-    assert not settings.WAGTAIL_2FA_REQUIRED
-    
+    assert getattr(settings, setting_name) == expected_value
 
-def test_sets_default_wagtail_mount_path(settings):
-    # WAGTAIL_MOUNT_PATH was already populated in the test environment
-    # Explicitly deleting it to ensure it's added when ready() is called
-    delattr(settings, 'WAGTAIL_MOUNT_PATH')
-    assert not hasattr(settings, 'WAGTAIL_MOUNT_PATH')
+
+@pytest.mark.parametrize("setting_name", [
+    'WAGTAIL_2FA_OTP_TOTP_NAME',
+    'WAGTAIL_SITE_NAME',
+    'OTP_TOTP_ISSUER'
+])
+def test_otp_totp_issuer(setting_name, settings):
+    setattr(settings, setting_name, 'wagtail-2fa')
+
     app_config = apps.get_app_config('wagtail_2fa')
     app_config.ready()
 
-    assert settings.WAGTAIL_MOUNT_PATH == ''
+    assert settings.OTP_TOTP_ISSUER == 'wagtail-2fa'


### PR DESCRIPTION
This sets the ``OTP_TOTP_ISSUER`` setting from django-otp under the hood, which makes it easier to identify which site is which in your authenticator app.

Should solve issue: #7