### PR TITLE
Make the package compatible with django-hosts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /dist/
 /docs/_build/
 /htmlcov/
+/.mypy_cache/
 
 
 # Editors

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+1.1.0 (2019-02-27)
+==================
+ - Make the package compatible with django-hosts. The middleware initially
+   resolved a number of paths on start up time, this is now lazy.
+
+
 1.0.1 (2019-01-18)
 ==================
  - Add Dutch translations (#9)


### PR DESCRIPTION
The middleware initially resolved a number of paths on start up time,
this is now lazy since the url resolving is with django hosts dynamic
based on the requests hostname