### PR TITLE
fix: updated middleware to work with django-otp 0.7.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -343,4 +343,3 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #
 # texinfo_no_detailmenu = False
-

--- a/sandbox/sandbox/urls.py
+++ b/sandbox/sandbox/urls.py
@@ -1,10 +1,11 @@
-import debug_toolbar
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
+
+import debug_toolbar
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),

--- a/src/wagtail_2fa/forms.py
+++ b/src/wagtail_2fa/forms.py
@@ -50,7 +50,6 @@ class DeviceForm(forms.ModelForm):
         self.fields["otp_token"].widget.attrs.update(
             {"autofocus": "autofocus", "autocomplete": "off"}
         )
-
         if self.instance.confirmed:
             del self.fields["otp_token"]
 

--- a/src/wagtail_2fa/middleware.py
+++ b/src/wagtail_2fa/middleware.py
@@ -1,11 +1,11 @@
+from functools import partial
+
 import django_otp
 from django.conf import settings
 from django.contrib.auth.views import redirect_to_login
-from django.urls import NoReverseMatch
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 from django.utils.functional import SimpleLazyObject
 from django_otp.middleware import OTPMiddleware as _OTPMiddleware
-from functools import partial
 
 
 class VerifyUserMiddleware(_OTPMiddleware):

--- a/src/wagtail_2fa/views.py
+++ b/src/wagtail_2fa/views.py
@@ -11,7 +11,8 @@ from django.utils.functional import cached_property
 from django.utils.http import is_safe_url
 from django.views.decorators.cache import never_cache
 from django.views.decorators.debug import sensitive_post_parameters
-from django.views.generic import DeleteView, FormView, ListView, UpdateView, View
+from django.views.generic import (
+    DeleteView, FormView, ListView, UpdateView, View)
 from django_otp import login as otp_login
 from django_otp.plugins.otp_totp.models import TOTPDevice
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,8 +1,9 @@
-from wagtail_2fa.middleware import VerifyUserMiddleware
+from django.test import override_settings
 from django.urls import reverse
 from django_otp import login as otp_login
 from django_otp.plugins.otp_totp.models import TOTPDevice
-from django.test import override_settings
+
+from wagtail_2fa.middleware import VerifyUserMiddleware
 
 
 def test_verified_request(rf, superuser):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,9 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django_otp.plugins.otp_totp.models import TOTPDevice
-from django.contrib.auth import get_user_model
-from unittest.mock import patch
+
 
 def test_device_list_view(admin_client):
     response = admin_client.get(reverse('wagtail_2fa_device_list'))


### PR DESCRIPTION
Updated middleware syntax to work with django_otp 0.7.0; remains compatible with 0.6.0. 