### PR TITLE
Allow admin to remove 2fa devices for other users

### DIFF
--- a/src/wagtail_2fa/templates/wagtail_2fa/device_confirm_delete.html
+++ b/src/wagtail_2fa/templates/wagtail_2fa/device_confirm_delete.html
@@ -9,7 +9,8 @@
     <div class="nice-padding">
         <p>{% trans 'Do you want to delete the device?' %}</p>
         <form method="post" action="{% url 'wagtail_2fa_device_remove' pk=object.pk %}">
-            <a href="{% url 'wagtail_2fa_device_list' %}" class="button button-secondary">{% trans 'Cancel' %}</a>
+            <input type="hidden" name="user_id" value="{{object.user.id}}" />
+            <a href="{% url 'wagtail_2fa_device_list' user_id=object.user.id %}" class="button button-secondary">{% trans 'Cancel' %}</a>
             <input type="submit" class="button warning" value="{% trans 'Remove device' %}">
             {% csrf_token %}
         </form>

--- a/src/wagtail_2fa/templates/wagtail_2fa/device_list.html
+++ b/src/wagtail_2fa/templates/wagtail_2fa/device_list.html
@@ -24,14 +24,22 @@
                                 </h2>
                             </td>
                             <td>
+                                {# Admins can remove existing devices from another user's account. #}
                                 <a href="{% url 'wagtail_2fa_device_remove' pk=device.pk %}" class="button">{% trans 'Remove device' %}</a>
-                                <a href="{% url 'wagtail_2fa_device_update' pk=device.pk %}" class="button">{% trans 'Update device' %}</a>
+
+                                {# Admins cannot update existing devices on another user's account. #}
+                                {% if request.user.id == device.user_id %}
+                                    <a href="{% url 'wagtail_2fa_device_update' pk=device.pk %}" class="button">{% trans 'Update device' %}</a>
+                                {% endif %}
                             </td>
                         </li>
                     {% endfor %}
                 </tbody>
             </table>
 
-        <a href="{% url 'wagtail_2fa_device_new' %}" class="button">{% trans 'New device' %}</a>
+        {# Users can only add devices to their own account #}
+        {% if user_id == request.user.id %}
+            <a href="{% url 'wagtail_2fa_device_new' %}" class="button">{% trans 'New device' %}</a>
+        {% endif %}
     </div>
 {% endblock %}

--- a/src/wagtail_2fa/templates/wagtail_2fa/device_list.html
+++ b/src/wagtail_2fa/templates/wagtail_2fa/device_list.html
@@ -37,7 +37,7 @@
 
                         <tr>
                             <td colspan="2">
-                                There are no devices for this user.
+                                {% trans "There are no devices for this user." %}
                             </td>
                         </tr>
                     {% endfor %}

--- a/src/wagtail_2fa/templates/wagtail_2fa/device_list.html
+++ b/src/wagtail_2fa/templates/wagtail_2fa/device_list.html
@@ -32,7 +32,14 @@
                                     <a href="{% url 'wagtail_2fa_device_update' pk=device.pk %}" class="button">{% trans 'Update device' %}</a>
                                 {% endif %}
                             </td>
-                        </li>
+                        </tr>
+                    {% empty %}
+
+                        <tr>
+                            <td colspan="2">
+                                There are no devices for this user.
+                            </td>
+                        </tr>
                     {% endfor %}
                 </tbody>
             </table>

--- a/src/wagtail_2fa/views.py
+++ b/src/wagtail_2fa/views.py
@@ -67,7 +67,7 @@ class DeviceListView(ListView):
         return TOTPDevice.objects.devices_for_user(self.kwargs['user_id'], confirmed=True)
 
     def get_context_data(self, **kwargs):
-        context = super(DeviceListView, self).get_context_data(**kwargs)
+        context = super().get_context_data(**kwargs)
         context['user_id'] = int(self.kwargs['user_id'])
         return context
 

--- a/src/wagtail_2fa/views.py
+++ b/src/wagtail_2fa/views.py
@@ -64,7 +64,12 @@ class DeviceListView(ListView):
     template_name = "wagtail_2fa/device_list.html"
 
     def get_queryset(self):
-        return TOTPDevice.objects.devices_for_user(self.request.user, confirmed=True)
+        return TOTPDevice.objects.devices_for_user(self.kwargs['user_id'], confirmed=True)
+
+    def get_context_data(self, **kwargs):
+        context = super(DeviceListView, self).get_context_data(**kwargs)
+        context['user_id'] = int(self.kwargs['user_id'])
+        return context
 
 
 class DeviceCreateView(FormView):
@@ -86,7 +91,7 @@ class DeviceCreateView(FormView):
         return super().form_valid(form)
 
     def get_success_url(self):
-        return reverse("wagtail_2fa_device_list")
+        return reverse('wagtail_2fa_device_list', kwargs={'user_id': self.request.user.id})
 
     @cached_property
     def device(self):
@@ -109,17 +114,18 @@ class DeviceUpdateView(UpdateView):
         return kwargs
 
     def get_success_url(self):
-        return reverse("wagtail_2fa_device_list")
+        return reverse('wagtail_2fa_device_list', kwargs={'user_id': self.request.user.id})
 
 
 class DeviceDeleteView(DeleteView):
     template_name = "wagtail_2fa/device_confirm_delete.html"
 
     def get_queryset(self):
-        return TOTPDevice.objects.devices_for_user(self.request.user, confirmed=True)
+        device = TOTPDevice.objects.get(**self.kwargs)
+        return TOTPDevice.objects.devices_for_user(device.user, confirmed=True)
 
     def get_success_url(self):
-        return reverse("wagtail_2fa_device_list")
+        return reverse('wagtail_2fa_device_list', kwargs={'user_id': self.request.POST.get('user_id')})
 
 
 class DeviceQRCodeView(View):

--- a/src/wagtail_2fa/wagtail_hooks.py
+++ b/src/wagtail_2fa/wagtail_hooks.py
@@ -14,7 +14,7 @@ def urlpatterns():
     return [
         url(r"^2fa/auth$", views.LoginView.as_view(), name="wagtail_2fa_auth"),
         url(
-            r"^2fa/devices/$",
+            r"^2fa/devices/(?P<user_id>\d+)$",
             views.DeviceListView.as_view(),
             name="wagtail_2fa_device_list",
         ),
@@ -45,13 +45,20 @@ def urlpatterns():
 def remove_menu_if_unverified(request, menu_items):
     if not request.user.is_verified() and settings.WAGTAIL_2FA_REQUIRED:
         menu_items.clear()
-        menu_items.append(MenuItem("2FA Setup", reverse("wagtail_2fa_device_list")))
+        menu_items.append(MenuItem("2FA Setup", reverse('wagtail_2fa_device_list', kwargs={'user_id': request.user.id})))
 
 
 @hooks.register("register_account_menu_item")
 def register(request):
     return {
-        "url": reverse("wagtail_2fa_device_list"),
+        "url": reverse('wagtail_2fa_device_list', kwargs={'user_id': request.user.id}),
         "label": _("Manage your 2FA devices"),
         "help_text": _("Add or remove devices for 2 factor authentication."),
     }
+
+@hooks.register('register_user_listing_buttons')
+def register_user_listing_buttons(context, user):
+    yield UserListingButton(    
+        _('Manage 2FA'),    
+        reverse('wagtail_2fa_device_list', kwargs={'user_id': user.id}),
+        attrs={'title': _('Edit this user')}, priority=100)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -60,3 +60,27 @@ def test_device_qr(admin_client, monkeypatch):
     endpoint = reverse('wagtail_2fa_device_qrcode')
     response = admin_client.get(endpoint)
     assert response.status_code == 200
+
+
+def test_delete_user_device_as_admin(admin_client, user, monkeypatch):
+    user = get_user_model().objects.filter(is_staff=False).first()
+    device = TOTPDevice.objects.create(name='Initial', user=user, confirmed=True)
+
+    endpoint = reverse('wagtail_2fa_device_remove', kwargs={'pk': device.id})
+    response = admin_client.post(endpoint, {
+        'user_id': user.id
+    })
+    assert response.status_code == 302
+    assert TOTPDevice.objects.all().count() == 0
+
+
+def test_delete_user_device_unauthorized(client, user, monkeypatch):
+    user = get_user_model().objects.filter(is_staff=False).first()
+    device = TOTPDevice.objects.create(name='Initial', user=user, confirmed=True)
+
+    endpoint = reverse('wagtail_2fa_device_remove', kwargs={'pk': device.id})
+    response = client.post(endpoint, {
+        'user_id': user.id
+    })
+    assert response.status_code == 302
+    assert TOTPDevice.objects.all().count() == 1


### PR DESCRIPTION
Our users are having the occasional issue with the Wagtail 2FA plugin. Their devices don't set up properly, or they lose their phone, etc. Because users can only remove their own devices, and our users *can't* login without a valid 2FA device, we're forced to run a SQL query to delete the record for them.

This pull request allows admins to delete the 2FA device for any other user, but prevents them from adding new devices, or updating existing devices. 

I followed these two principles while working on this code:
* An admin should be able to remove a 2fa device for any user
* An admin should not be able to add or update a device for any user
