### PR TITLE
Don't remove menu items if 2FA is disabled

### DIFF
--- a/src/wagtail_2fa/wagtail_hooks.py
+++ b/src/wagtail_2fa/wagtail_hooks.py
@@ -45,10 +45,10 @@ def urlpatterns():
 @hooks.register("construct_main_menu")
 def remove_menu_if_unverified(request, menu_items):
     """Remove the sidebar menu items if the user is unverified."""
-    if getattr(request.user, "enable_2fa", True):
-        if not (request.user.is_verified() and settings.WAGTAIL_2FA_REQUIRED):
-            menu_items.clear()
-            menu_items.append(MenuItem("2FA Setup", reverse('wagtail_2fa_device_list', kwargs={'user_id': request.user.id})))
+    if (settings.WAGTAIL_2FA_REQUIRED and getattr(request.user, "enable_2fa", True)
+            and not request.user.is_verified()):
+        menu_items.clear()
+        menu_items.append(MenuItem("2FA Setup", reverse('wagtail_2fa_device_list', kwargs={'user_id': request.user.id})))
 
 
 @hooks.register("register_account_menu_item")

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,80 @@
+from wagtail_2fa.wagtail_hooks import remove_menu_if_unverified
+from django.test import override_settings
+from wagtail.admin.menu import MenuItem
+from django_otp.middleware import OTPMiddleware as _OTPMiddleware
+from django_otp import user_has_device
+
+
+class TestHooks:
+    def test_remove_menu_if_unverified(self, user, rf):
+        with override_settings(WAGTAIL_2FA_REQUIRED=True):
+            request = rf.get('/cms/')
+            request.user = user
+            middleware = _OTPMiddleware()
+            user = middleware._verify_user(request, user)
+            assert not user_has_device(user)
+            assert user.is_authenticated
+
+            menu_items = [
+                MenuItem("Dummy item 1", "/stub1/"),
+                MenuItem("Dummy item 2", "/stub2/"),
+                MenuItem("Dummy item 3", "/stub3/")
+                ]
+
+            remove_menu_if_unverified(request, menu_items)
+
+            assert len(menu_items) == 1
+            assert menu_items[0].label == "2FA Setup"
+            assert menu_items[0].url == "/cms/2fa/devices/1"
+
+    def test_do_not_remove_menu_if_verified(self, verified_user, rf):
+        with override_settings(WAGTAIL_2FA_REQUIRED=True):
+            request = rf.get('/cms/')
+            request.user = verified_user
+
+            menu_items = [
+                MenuItem("Dummy item 1", "/stub1/"),
+                MenuItem("Dummy item 2", "/stub2/"),
+                MenuItem("Dummy item 3", "/stub3/")
+                ]
+
+            remove_menu_if_unverified(request, menu_items)
+
+            assert menu_items == menu_items
+
+    def test_do_not_remove_menu_if_2fa_required_is_false(
+            self, user, rf):
+        with override_settings(WAGTAIL_2FA_REQUIRED=False):
+            request = rf.get('/cms/')
+
+            # Use a regular user here to make sure the menu still works
+            # even when the middleware is not loaded and the user does not have the
+            # enable_2fa permission.
+            request.user = user
+            assert getattr(request.user, "enable_2fa", None) is None
+
+            menu_items = [
+                MenuItem("Dummy item 1", "/stub1/"),
+                MenuItem("Dummy item 2", "/stub2/"),
+                MenuItem("Dummy item 3", "/stub3/")
+                ]
+
+            remove_menu_if_unverified(request, menu_items)
+
+            assert menu_items == menu_items
+
+    def test_do_not_remove_menu_if_2fa_required_is_false_for_verified_user(
+            self, verified_user, rf):
+        with override_settings(WAGTAIL_2FA_REQUIRED=False):
+            request = rf.get('/cms/')
+            request.user = verified_user
+
+            menu_items = [
+                MenuItem("Dummy item 1", "/stub1/"),
+                MenuItem("Dummy item 2", "/stub2/"),
+                MenuItem("Dummy item 3", "/stub3/")
+                ]
+
+            remove_menu_if_unverified(request, menu_items)
+
+            assert menu_items == menu_items

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -9,14 +9,14 @@ from django_otp.plugins.otp_totp.models import TOTPDevice
 def test_device_list_view(admin_client, django_assert_num_queries):
     user = get_user_model().objects.filter(is_staff=True).first()
 
-    with django_assert_num_queries(6):
+    with django_assert_num_queries(9):
         response = admin_client.get(reverse('wagtail_2fa_device_list',
                                     kwargs={'user_id': user.id}))
         assert response.status_code == 200
 
 
 def test_device_list_create(admin_client, monkeypatch, django_assert_num_queries):
-    with django_assert_num_queries(8):
+    with django_assert_num_queries(11):
         response = admin_client.get(reverse('wagtail_2fa_device_new'))
         assert response.status_code == 200
 


### PR DESCRIPTION
Fixes #33.
The observed query count is increased because the WAGTAIL_2FA_REQUIRED
setting was not properly checked before this fix.