### PR TITLE
Fix/manage devices

### DIFF
--- a/src/wagtail_2fa/middleware.py
+++ b/src/wagtail_2fa/middleware.py
@@ -109,8 +109,10 @@ class VerifyUserPermissionsMiddleware(VerifyUserMiddleware):
     def _require_verified_user(self, request):
         result = super()._require_verified_user(request)
 
-        # Don't require verification if the user has 2FA disabled
-        if not request.user.has_perms(["wagtailadmin.enable_2fa"]):
+        # Always require verification if the user has a device, even if they have
+        # 2FA disabled.
+        user_has_device = django_otp.user_has_device(request.user, confirmed=True)
+        if not user_has_device and not request.user.has_perms(["wagtailadmin.enable_2fa"]):
             return False
 
         return result

--- a/src/wagtail_2fa/mixins.py
+++ b/src/wagtail_2fa/mixins.py
@@ -1,3 +1,4 @@
+from django.urls import reverse
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.contrib.auth.views import redirect_to_login
@@ -15,11 +16,17 @@ class OtpRequiredMixin(object):
     if_configured = False
 
     def handle_no_permission(self, request):
-        """Redirect unauthenticated users to login else raise PermissionDenied"""
+        """Redirect unauthenticated users."""
         if not request.user.is_authenticated:
             return redirect_to_login(
                 request.get_full_path(), settings.LOGIN_URL, REDIRECT_FIELD_NAME
             )
+
+        if user_has_device(request.user):
+            return redirect_to_login(
+                request.get_full_path(), login_url=reverse("wagtail_2fa_auth")
+            )
+
         raise PermissionDenied
 
     def user_allowed(self, user):
@@ -28,7 +35,6 @@ class OtpRequiredMixin(object):
         )
 
     def dispatch(self, request, *args, **kwargs):
-
         if not self.user_allowed(request.user):
             return self.handle_no_permission(request)
 

--- a/src/wagtail_2fa/mixins.py
+++ b/src/wagtail_2fa/mixins.py
@@ -30,6 +30,9 @@ class OtpRequiredMixin(object):
         raise PermissionDenied
 
     def user_allowed(self, user):
+        if not settings.WAGTAIL_2FA_REQUIRED:
+            return True
+
         return user.is_verified() or (
             self.if_configured and user.is_authenticated and not user_has_device(user)
         )

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from django.test import override_settings
 from django.urls import reverse
 from django_otp.plugins.otp_totp.models import TOTPDevice
 from django_otp.middleware import OTPMiddleware as _OTPMiddleware
@@ -9,50 +11,55 @@ from django_otp import user_has_device
 
 class TestOtpRequiredMixin:
     def test_handle_no_permission_raises_if_authenticated(self, rf, user):
-        request = rf.get('/admin/')
-        request.user = user
+        with override_settings(WAGTAIL_2FA_REQUIRED=True):
+            request = rf.get('/admin/')
+            request.user = user
 
-        mixin = OtpRequiredMixin()
+            mixin = OtpRequiredMixin()
 
-        with pytest.raises(PermissionDenied):
-            mixin.handle_no_permission(request)
+            with pytest.raises(PermissionDenied):
+                mixin.handle_no_permission(request)
 
     def test_handle_no_permission_redirects_to_login_if_not_authenticated(self, rf):
-        request = rf.get('/admin/')
+        with override_settings(WAGTAIL_2FA_REQUIRED=True):
+            request = rf.get('/admin/')
 
-        mixin = OtpRequiredMixin()
-        response = mixin.handle_no_permission(request)
-        assert response.status_code == 302
-        assert response.url == '/accounts/login/?next=/admin/'
+            mixin = OtpRequiredMixin()
+            response = mixin.handle_no_permission(request)
+            assert response.status_code == 302
+            assert response.url == '/accounts/login/?next=/admin/'
 
     def test_handle_no_permission_redirects_to_auth_if_user_has_device(self, rf, user):
-        device = TOTPDevice.objects.create(user=user, confirmed=True)
-        request = rf.get('/admin/')
-        request.user = user
+        with override_settings(WAGTAIL_2FA_REQUIRED=True):
+            device = TOTPDevice.objects.create(user=user, confirmed=True)
+            request = rf.get('/admin/')
+            request.user = user
 
-        mixin = OtpRequiredMixin()
-        response = mixin.handle_no_permission(request)
-        assert response.status_code == 302
+            mixin = OtpRequiredMixin()
+            response = mixin.handle_no_permission(request)
+            assert response.status_code == 302
 
-        url_auth = reverse('wagtail_2fa_auth')
-        assert response.url == f"{url_auth}?next=/admin/"
+            url_auth = reverse('wagtail_2fa_auth')
+            assert response.url == f"{url_auth}?next=/admin/"
 
     def test_user_allowed_with_verified_user_returns_true(self, rf, verified_user):
-        user = verified_user
+        with override_settings(WAGTAIL_2FA_REQUIRED=True):
+            user = verified_user
 
-        mixin = OtpRequiredMixin()
-        result = mixin.user_allowed(user)
-        assert result is True
+            mixin = OtpRequiredMixin()
+            result = mixin.user_allowed(user)
+            assert result is True
 
     def test_user_allowed_when_no_device_and_if_configured_returns_true(self, rf, user):
-        request = rf.get('/admin/')
-        request.user = user
-        middleware = _OTPMiddleware()
-        user = middleware._verify_user(request, user)
-        assert not user_has_device(user)
-        assert user.is_authenticated
+        with override_settings(WAGTAIL_2FA_REQUIRED=True):
+            request = rf.get('/admin/')
+            request.user = user
+            middleware = _OTPMiddleware()
+            user = middleware._verify_user(request, user)
+            assert not user_has_device(user)
+            assert user.is_authenticated
 
-        mixin = OtpRequiredMixin()
-        mixin.if_configured = True
-        result = mixin.user_allowed(user)
-        assert result is True
+            mixin = OtpRequiredMixin()
+            mixin.if_configured = True
+            result = mixin.user_allowed(user)
+            assert result is True

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -8,13 +8,18 @@ from django_otp.plugins.otp_totp.models import TOTPDevice
 from wagtail_2fa.views import DeviceListView
 
 
-def test_device_list_view(admin_client, django_assert_num_queries):
+def test_device_list_view(admin_client, admin_user, django_assert_num_queries):
     with override_settings(WAGTAIL_2FA_REQUIRED=True):
-        user = get_user_model().objects.filter(is_staff=True).first()
+        admin_device = TOTPDevice.objects.create(name='Initial', user=admin_user, confirmed=True)
 
-        with django_assert_num_queries(9):
+        session = admin_client.session
+        session[DEVICE_ID_SESSION_KEY] = admin_device.persistent_id
+        session.save()
+
+
+        with django_assert_num_queries(10):
             response = admin_client.get(reverse('wagtail_2fa_device_list',
-                                        kwargs={'user_id': user.id}))
+                                        kwargs={'user_id': admin_user.id}))
             assert response.status_code == 200
 
 


### PR DESCRIPTION
This fixes #35 . When a user had a OTP device and tried to click on the 'Manage your 2FA devices' button, and `WAGTAIL_2FA_REQUIRED` was false or they were in a group which did not have 2FA enabled, they would get a 403 forbidden error page and were unable to manage their devices.

This has been fixed by requiring users to always verify themselves if they have a OTP device, even if they are not in a group which enforces 2FA.