### PR TITLE
Replaces "staticfiles" with "static"

### DIFF
--- a/src/wagtail_2fa/templates/wagtail_2fa/otp_form.html
+++ b/src/wagtail_2fa/templates/wagtail_2fa/otp_form.html
@@ -1,5 +1,5 @@
 {% extends "wagtailadmin/admin_base.html" %}
-{% load staticfiles i18n %}
+{% load static i18n %}
 {% block titletag %}{% trans "Sign in" %}{% endblock %}
 {% block bodyclass %}login{% endblock %}
 


### PR DESCRIPTION
`staticfiles` is deprecated since Django 1.10, switching it to `static` brings support for Django 3 for free.