### PR TITLE
corrected flake8-debugger version bump

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ tests_require = [
     'isort==4.2.5',
     'flake8==3.0.3',
     'flake8-blind-except==0.1.1',
-    'flake8-debugger==1.4.1',
+    'flake8-debugger==1.4.0',
 ]
 
 with open('README.rst') as fh:


### PR DESCRIPTION
flake8-debugger was bumped to 1.4.1 and this release doesn't exist reverted to 1.4.0