### PR TITLE
WIP: Update dependency versions

### DIFF
--- a/sandbox/sandbox/apps/user/forms.py
+++ b/sandbox/sandbox/apps/user/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.contrib.auth.forms import ReadOnlyPasswordHashField
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from sandbox.apps.user import models
 

--- a/sandbox/sandbox/apps/user/models.py
+++ b/sandbox/sandbox/apps/user/models.py
@@ -1,10 +1,9 @@
 from django.contrib.auth.models import (
     AbstractBaseUser, PermissionsMixin, UserManager)
 from django.core.mail import send_mail
-from django.db import connections, models
-from django.dispatch import receiver
+from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class User(AbstractBaseUser, PermissionsMixin):

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,6 @@ tag_name = {new_version}
 
 [tool:pytest]
 minversion = 3.0
-strict = true
 testpaths = tests
 
 [wheel]
@@ -23,15 +22,14 @@ max-line-length = 99
 
 [coverage:run]
 branch = True
-source = 
+source =
 	wagtail_2fa
 
 [coverage:paths]
-source = 
+source =
 	src/wagtail_2fa
 	.tox/*/lib/python*/site-packages/wagtail_2fa
 	.tox/pypy*/site-packages/wagtail_2fa
 
 [coverage:report]
 show_missing = True
-

--- a/src/wagtail_2fa/forms.py
+++ b/src/wagtail_2fa/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.contrib.auth import authenticate
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_otp.forms import OTPAuthenticationFormMixin
 from django_otp.plugins.otp_totp.models import TOTPDevice
 

--- a/src/wagtail_2fa/utils.py
+++ b/src/wagtail_2fa/utils.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
 

--- a/src/wagtail_2fa/views.py
+++ b/src/wagtail_2fa/views.py
@@ -82,6 +82,7 @@ class DeviceListView(OtpRequiredMixin, ListView):
         Users are always allowed to list their own 2FA devices.
         If they have the ``change_user`` permission, they are allowed
         to list other users' 2FA devices.
+
         """
         if (int(self.kwargs["user_id"]) == request.user.pk or
                 request.user.has_perm("user.change_user")):

--- a/src/wagtail_2fa/wagtail_hooks.py
+++ b/src/wagtail_2fa/wagtail_hooks.py
@@ -1,7 +1,6 @@
 from django.conf import settings
-from django.conf.urls import url
-from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.urls import reverse, path, re_path
+from django.utils.translation import gettext_lazy as _
 from wagtail.admin.menu import MenuItem
 from wagtail.core import hooks
 from wagtail.users.widgets import UserListingButton
@@ -13,28 +12,28 @@ from django.contrib.auth.models import Permission
 @hooks.register("register_admin_urls")
 def urlpatterns():
     return [
-        url(r"^2fa/auth$", views.LoginView.as_view(), name="wagtail_2fa_auth"),
-        url(
+        path("2fa/auth", views.LoginView.as_view(), name="wagtail_2fa_auth"),
+        re_path(
             r"^2fa/devices/(?P<user_id>\d+)$",
             views.DeviceListView.as_view(),
             name="wagtail_2fa_device_list",
         ),
-        url(
-            r"^2fa/devices/new$",
+        path(
+            "2fa/devices/new",
             views.DeviceCreateView.as_view(),
             name="wagtail_2fa_device_new",
         ),
-        url(
+        re_path(
             r"^2fa/devices/(?P<pk>\d+)/update$",
             views.DeviceUpdateView.as_view(),
             name="wagtail_2fa_device_update",
         ),
-        url(
+        re_path(
             r"^2fa/devices/(?P<pk>\d+)/remove$",
             views.DeviceDeleteView.as_view(),
             name="wagtail_2fa_device_remove",
         ),
-        url(
+        re_path(
             r"^2fa/devices/qr-code$",
             views.DeviceQRCodeView.as_view(),
             name="wagtail_2fa_device_qrcode",
@@ -61,8 +60,8 @@ def register(request):
 
 @hooks.register('register_user_listing_buttons')
 def register_user_listing_buttons(context, user):
-    yield UserListingButton(    
-        _('Manage 2FA'),    
+    yield UserListingButton(
+        _('Manage 2FA'),
         reverse('wagtail_2fa_device_list', kwargs={'user_id': user.id}),
         attrs={'title': _('Edit this user')}, priority=100)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,6 @@ def pytest_configure():
             'django.contrib.messages.middleware.MessageMiddleware',
             'django.middleware.clickjacking.XFrameOptionsMiddleware',
             'wagtail_2fa.middleware.VerifyUserMiddleware',
-            'wagtail.core.middleware.SiteMiddleware',
         ],
         STATIC_URL='/static/',
         INSTALLED_APPS=[

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -12,7 +12,7 @@ from django_otp import DEVICE_ID_SESSION_KEY
 from django_otp.plugins.otp_totp.models import TOTPDevice
 from wagtail_2fa.views import DeviceListView, DeviceDeleteView, DeviceUpdateView
 
-def test_device_list_view(admin_client, admin_user, django_assert_num_queries):
+def test_device_list_view(admin_client, admin_user, django_assert_max_num_queries):
     with override_settings(WAGTAIL_2FA_REQUIRED=True):
         admin_device = TOTPDevice.objects.create(name='Initial', user=admin_user, confirmed=True)
 
@@ -21,15 +21,15 @@ def test_device_list_view(admin_client, admin_user, django_assert_num_queries):
         session.save()
 
 
-        with django_assert_num_queries(10):
+        with django_assert_max_num_queries(13):
             response = admin_client.get(reverse('wagtail_2fa_device_list',
                                         kwargs={'user_id': admin_user.id}))
             assert response.status_code == 200
 
 
-def test_device_list_create(admin_client, monkeypatch, django_assert_num_queries):
+def test_device_list_create(admin_client, django_assert_max_num_queries):
     with override_settings(WAGTAIL_2FA_REQUIRED=True):
-        with django_assert_num_queries(9):
+        with django_assert_max_num_queries(10):
             response = admin_client.get(reverse('wagtail_2fa_device_new'))
             assert response.status_code == 200
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,12 +1,12 @@
-from django.conf.urls import include, url
 from django.contrib import admin
+from django.urls import path, include
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.core import urls as wagtail_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^cms/', include(wagtailadmin_urls)),
-    url(r'^documents/', include(wagtaildocs_urls)),
-    url(r'', include(wagtail_urls)),
+    path('admin/', admin.site.urls),
+    path('cms/', include(wagtailadmin_urls)),
+    path('documents/', include(wagtaildocs_urls)),
+    path('', include(wagtail_urls)),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,14 @@
 [tox]
-envlist = py{36,37,38}-django{22,30}-wagtail{27,29}
+envlist = py{37,38}-django{22,30,31}-wagtail{210,211}
 
 [testenv]
-commands = coverage run --parallel -m pytest {posargs}
+commands = coverage run --parallel -m pytest {posargs} -vvv
 deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
-    wagtail27: wagtail>=2.7,<2.8 # LTS
-    wagtail29: wagtail>=2.9,<2.10
+    django31: Django>=3.1,<3.2
+    wagtail210: wagtail>=2.10,<2.11
+    wagtail211: wagtail>=2.11,<2.12  # LTS
 extras = test
 
 # Uses default basepython otherwise reporting doesn't work on Travis where


### PR DESCRIPTION
As of February 1st Wagtail 2.7 (previous LTS) isn't supported anymore. This PR drops support for all Wagtail versions prior 2.10 (one version before the latest LTS). 

_Note: this PR isn't tested in a project yet, hope to do that in the upcoming week_