### PR TITLE
Fix sandbox when running under Wagtail 2.12

### DIFF
--- a/sandbox/requirements.txt
+++ b/sandbox/requirements.txt
@@ -1,4 +1,4 @@
 Django>=2.2
-wagtail>=2.7
+wagtail>=2.12
 django-debug-toolbar==2.2
 -e .[docs,test]

--- a/sandbox/sandbox/settings.py
+++ b/sandbox/sandbox/settings.py
@@ -81,7 +81,6 @@ MIDDLEWARE = [
 
     'wagtail_2fa.middleware.VerifyUserPermissionsMiddleware',
 
-    'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 ]
 


### PR DESCRIPTION
Sandbox is broken when following install instructions (due to pulling in Wagtail 2.12 which has completely removed SiteMiddleware).