### PR TITLE
Add support for Django 4.0

### DIFF
--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -10,85 +10,37 @@ jobs:
       max-parallel: 4
       matrix:
         tox_env:
-          - py37-django22-wagtail210
-          - py37-django22-wagtail211
-          - py37-django22-wagtail212
-          - py37-django22-wagtail213
-          - py37-django30-wagtail210
-          - py37-django30-wagtail211
-          - py37-django30-wagtail212
-          - py37-django30-wagtail213
-          - py37-django31-wagtail210
-          - py37-django31-wagtail211
-          - py37-django31-wagtail212
-          - py37-django31-wagtail213
-          - py37-django32-wagtail213
-          - py38-django22-wagtail210
-          - py38-django22-wagtail211
-          - py38-django22-wagtail212
-          - py38-django22-wagtail213
-          - py38-django30-wagtail210
-          - py38-django30-wagtail211
-          - py38-django30-wagtail212
-          - py38-django30-wagtail213
-          - py38-django31-wagtail210
-          - py38-django31-wagtail211
-          - py38-django31-wagtail212
-          - py38-django31-wagtail213
-          - py38-django32-wagtail213
+          - py37-django32-wagtail215
+          - py38-django32-wagtail215
+          - py38-django32-wagtail216
+          - py38-django40-wagtail216
+          - py39-django32-wagtail215
+          - py39-django32-wagtail216
+          - py39-django40-wagtail216
+          - py310-django32-wagtail215
+          - py310-django32-wagtail216
+          - py310-django40-wagtail216
         include:
           - python-version: "3.7"
-            tox_env: py37-django22-wagtail210
-          - python-version: "3.7"
-            tox_env: py37-django22-wagtail211
-          - python-version: "3.7"
-            tox_env: py37-django22-wagtail212
-          - python-version: "3.7"
-            tox_env: py37-django22-wagtail213
-          - python-version: "3.7"
-            tox_env: py37-django30-wagtail210
-          - python-version: "3.7"
-            tox_env: py37-django30-wagtail211
-          - python-version: "3.7"
-            tox_env: py37-django30-wagtail212
-          - python-version: "3.7"
-            tox_env: py37-django30-wagtail213
-          - python-version: "3.7"
-            tox_env: py37-django31-wagtail210
-          - python-version: "3.7"
-            tox_env: py37-django31-wagtail211
-          - python-version: "3.7"
-            tox_env: py37-django31-wagtail212
-          - python-version: "3.7"
-            tox_env: py37-django31-wagtail213
-          - python-version: "3.7"
-            tox_env: py37-django32-wagtail213
+            tox_env: py37-django32-wagtail215
           - python-version: "3.8"
-            tox_env: py38-django22-wagtail210
+            tox_env: py38-django32-wagtail215
           - python-version: "3.8"
-            tox_env: py38-django22-wagtail211
+            tox_env: py38-django32-wagtail216
           - python-version: "3.8"
-            tox_env: py38-django22-wagtail212
-          - python-version: "3.8"
-            tox_env: py38-django22-wagtail213
-          - python-version: "3.8"
-            tox_env: py38-django30-wagtail210
-          - python-version: "3.8"
-            tox_env: py38-django30-wagtail211
-          - python-version: "3.8"
-            tox_env: py38-django30-wagtail212
-          - python-version: "3.8"
-            tox_env: py38-django30-wagtail213
-          - python-version: "3.8"
-            tox_env: py38-django31-wagtail210
-          - python-version: "3.8"
-            tox_env: py38-django31-wagtail211
-          - python-version: "3.8"
-            tox_env: py38-django31-wagtail212
-          - python-version: "3.8"
-            tox_env: py38-django31-wagtail213
-          - python-version: "3.8"
-            tox_env: py38-django32-wagtail213
+            tox_env: py38-django40-wagtail216
+          - python-version: "3.9"
+            tox_env: py39-django32-wagtail215
+          - python-version: "3.9"
+            tox_env: py39-django32-wagtail216
+          - python-version: "3.9"
+            tox_env: py39-django40-wagtail216
+          - python-version: "3.10"
+            tox_env: py310-django32-wagtail215
+          - python-version: "3.10"
+            tox_env: py310-django32-wagtail216
+          - python-version: "3.10"
+            tox_env: py310-django40-wagtail216
 
     steps:
     - uses: actions/checkout@v1

--- a/sandbox/requirements.txt
+++ b/sandbox/requirements.txt
@@ -1,4 +1,4 @@
-Django>=2.2
-wagtail>=2.12
+Django>=3.2
+wagtail>=2.15
 django-debug-toolbar==3.2.2
 -e .[docs,test]

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ import re
 from setuptools import find_packages, setup
 
 install_requires = [
-    "Django>=2.2",
-    "Wagtail>=2.10",
+    "Django>=3.2",
+    "Wagtail>=2.15",
     "django-otp>=0.8.1",
     "six>=1.14.0",
     "qrcode>=6.1",
@@ -46,7 +46,7 @@ setup(
         "docs": docs_require,
         "test": tests_require,
     },
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     use_scm_version=True,
     entry_points={},
     package_dir={"": "src"},
@@ -57,14 +57,14 @@ setup(
         "Development Status :: 4 - Beta",
         "Environment :: Web Environment",
         "Framework :: Django",
-        "Framework :: Django :: 1.11",
-        "Framework :: Django :: 2.2",
-        "Framework :: Django :: 3.0",
+        "Framework :: Django :: 3.2",
+        "Framework :: Django :: 4.0",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     zip_safe=False,
 )

--- a/src/wagtail_2fa/views.py
+++ b/src/wagtail_2fa/views.py
@@ -9,7 +9,7 @@ from django.shortcuts import resolve_url
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.cache import never_cache
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.generic import DeleteView, FormView, ListView, UpdateView, View
@@ -49,7 +49,7 @@ class LoginView(SuccessURLAllowedHostsMixin, FormView):
         redirect_to = self.request.POST.get(
             self.redirect_field_name, self.request.GET.get(self.redirect_field_name, "")
         )
-        url_is_safe = is_safe_url(
+        url_is_safe = url_has_allowed_host_and_scheme(
             url=redirect_to,
             allowed_hosts=self.get_success_url_allowed_hosts(),
             require_https=self.request.is_secure(),

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,15 @@
 [tox]
-envlist = py{37,38}-django{22,30,31}-wagtail{210,211,212,213},py{37,38}-django32-wagtail213
+envlist =
+    py{37,38,39,310}-django32-wagtail215
+    py{38,39,310}-django{32,40}-wagtail216
 
 [testenv]
 commands = coverage run --parallel -m pytest {posargs} -vvv
 deps =
-    django22: Django>=2.2,<2.3
-    django30: Django>=3.0,<3.1
-    django31: Django>=3.1,<3.2
-    django32: Django>=3.2,<3.3
-    wagtail210: wagtail>=2.10,<2.11
-    wagtail211: wagtail>=2.11,<2.12  # LTS
-    wagtail212: wagtail>=2.12,<2.13
-    wagtail213: wagtail>=2.13,<2.14
+    django32: Django>=3.2,<4.0
+    django40: Django>=4.0,<4.1
+    wagtail215: wagtail>=2.15,<2.16  # LTS
+    wagtail216: wagtail>=2.16,<2.17
 extras = test
 
 [testenv:coverage-report]


### PR DESCRIPTION
Trying to update a project, and seeing the following:

```
  File "/Users/tomkins/Python/wagtail-2fa/src/wagtail_2fa/wagtail_hooks.py", line 9, in <module>
    from wagtail_2fa import views
  File "/Users/tomkins/Python/wagtail-2fa/src/wagtail_2fa/views.py", line 12, in <module>
    from django.utils.http import is_safe_url
ImportError: cannot import name 'is_safe_url' from 'django.utils.http' (/Users/tomkins/.virtualenvs/devsoc/lib/python3.10/site-packages/django/utils/http.py)
```

Which was removed from Django 4.0: https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0

I've also bumped up the supported versions quite a bit based on what is currently supported. Although Django 2.2 is supported for the rest of the month - no active version of Wagtail supports it.