### PR TITLE
Adds a new custom permission that will show in the user admin.

### DIFF
--- a/src/wagtail_2fa/middleware.py
+++ b/src/wagtail_2fa/middleware.py
@@ -96,7 +96,7 @@ class VerifyUserPermissionsMiddleware(VerifyUserMiddleware):
 
         # Add an attribute to the user so we can easily determine if 2FA should
         # be enabled for them.
-        request.user.enable_2fa = request.user.has_perms(["wagtailadmin.enable_2fa"])
+        request.user.enable_2fa = request.user.has_perms(["wagtail_2fa.enable_2fa"])
 
         return result
 
@@ -107,7 +107,7 @@ class VerifyUserPermissionsMiddleware(VerifyUserMiddleware):
         # 2FA disabled.
         user_has_device = django_otp.user_has_device(request.user, confirmed=True)
         if not user_has_device and not request.user.has_perms(
-            ["wagtailadmin.enable_2fa"]
+            ["wagtail_2fa.enable_2fa"]
         ):
             return False
 

--- a/src/wagtail_2fa/migrations/0002_custom_permission.py
+++ b/src/wagtail_2fa/migrations/0002_custom_permission.py
@@ -1,0 +1,43 @@
+from django.db import migrations
+
+
+def create_2fa_permissions(apps, schema_editor):
+    ContentType = apps.get_model('contenttypes.ContentType')
+    Permission = apps.get_model('auth.Permission')
+
+    wagtail_2fa_content_type, created = ContentType.objects.get_or_create(
+        app_label='wagtail_2fa',
+        model='admin'
+    )
+
+    # Create 2FA permission
+    enable_2fa_permission, created = Permission.objects.get_or_create(
+        content_type=wagtail_2fa_content_type,
+        codename='enable_2fa',
+        name='Enable 2FA'
+    )
+
+
+def remove_2fa_permissions(apps, schema_editor):
+    """Reverse the above additions of permissions."""
+    ContentType = apps.get_model('contenttypes.ContentType')
+    Permission = apps.get_model('auth.Permission')
+    wagtail_2fa_content_type = ContentType.objects.get(
+        app_label='wagtail_2fa',
+        model='admin',
+    )
+
+    # This also removes the permission from all groups
+    Permission.objects.filter(
+        content_type=wagtail_2fa_content_type,
+        codename='enable_2fa',
+    ).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = []
+
+    operations = [
+        migrations.RunPython(create_2fa_permissions, remove_2fa_permissions),
+    ]

--- a/src/wagtail_2fa/wagtail_hooks.py
+++ b/src/wagtail_2fa/wagtail_hooks.py
@@ -81,7 +81,7 @@ def register_user_listing_buttons(context, user):
 def register_2fa_permission():
     if "wagtail_2fa.middleware.VerifyUserPermissionsMiddleware" in settings.MIDDLEWARE:
         return Permission.objects.filter(
-            content_type__app_label="wagtailadmin", codename="enable_2fa"
+            content_type__app_label="wagtail_2fa", codename="enable_2fa"
         )
 
     return Permission.objects.none()


### PR DESCRIPTION
Im not sure when this bug occurred, but at the moment its not possible to see the enable_2fa permission in the groups admin. This is because of this bit of wagtail code:
```python
    for content_type_id in content_type_ids:
        content_perms = permissions.filter(content_type_id=content_type_id)
        content_perms_dict = {}
        custom_perms = []

        if content_perms[0].content_type.name == "admin":
            perm = content_perms[0]
            other_perms.append((perm, checkboxes_by_id[perm.id]))
            continue
```
https://github.com/wagtail/wagtail/blob/main/wagtail/users/templatetags/wagtailusers_tags.py#L55-L65

Essentially, it only grabs the first permission for the admin content type. So the one for Wagtail 2FA gets left out.
For a project im working on i've had to create some custom permissions and middleware to get around this. But i believe we can fix it here.

I've simply created a new permission under the wagtail_2fa contentype. This means it will be treated like any other custom permission to wagtail and show in the admin.