### PR TITLE
Allow wagtailadmin_sprite url in middleware

### DIFF
--- a/src/wagtail_2fa/middleware.py
+++ b/src/wagtail_2fa/middleware.py
@@ -14,6 +14,7 @@ class VerifyUserMiddleware(_OTPMiddleware):
         "wagtailadmin_login",
         "wagtailadmin_logout",
         "wagtailadmin_javascript_catalog",
+        "wagtailadmin_sprite",
     ]
 
     # These URLs do not require verification if the user has no devices


### PR DESCRIPTION
Since wagtail will inject whatever is in the url that gets returned from wagtailadmin_sprite, the create device template gets rendered twice.