### PR TITLE
Added support for wagtail 6.2 and above

### DIFF
--- a/src/wagtail_2fa/templates/wagtail_2fa/otp_form_v6.html
+++ b/src/wagtail_2fa/templates/wagtail_2fa/otp_form_v6.html
@@ -1,0 +1,66 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n wagtailadmin_tags %}
+{% block titletag %}{% trans "Sign in" %}{% endblock %}
+{% block bodyclass %}login{% endblock %}
+
+{% block furniture %}
+    <main class="content-wrapper" id="main">
+        <h1>{% block branding_login %}{% trans "Enter your two-factor authentication code" %}{% endblock %}</h1>
+
+        <div class="messages" role="status">
+            {# Always show messages div so it can be appended to by JS #}
+            {% if messages or form.errors %}
+                <ul>
+                    {% if form.errors %}
+                        <li class="error">{% blocktrans %}Invalid code{% endblocktrans %}</li>
+                    {% endif %}
+                    {% for message in messages %}
+                        <li class="{{ message.tags }}">{{ message }}</li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+        </div>
+
+        {% block above_login %}{% endblock %}
+
+        <form action="{% url 'wagtail_2fa_auth' %}" method="post" autocomplete="off" novalidate>
+            {% block login_form %}
+                {% csrf_token %}
+
+                {% url 'wagtailadmin_home' as home_url %}
+                <input type="hidden" name="next" value="{{ next|default:home_url }}" />
+
+                {% block fields %}
+                    {% formattedfield field=form.otp_token %}
+                    {% block extra_fields %}
+                        {% for field_name, field in form.extra_fields %}
+                            {% formattedfield field=field %}
+                        {% endfor %}
+                    {% endblock extra_fields %}
+                {% endblock %}
+            {% endblock %}
+            <footer class="form-actions">
+                {% block submit_buttons %}
+                    <button type="submit" class="button button-longrunning" tabindex="3" data-controller="w-progress" data-action="w-progress#activate" data-w-progress-active-value="{% trans 'Signing in…' %}">{% icon name="spinner" %}<em>{% trans 'Sign in' %}</em></button>
+
+                    <span style="margin-top:1rem;display:block;">
+                        <button type="submit" class="button button-secondary"
+                            formaction="{% url 'wagtailadmin_logout' %}?next={% url 'wagtailadmin_login' %}" formmethod="post" tabindex="4">
+                            {% trans "Sign out" %}
+                        </button>
+                    </span>
+                {% endblock %}
+            </footer>
+        </form>
+
+        {% block below_login %}{% endblock %}
+
+        {% block branding_logo %}
+            <div class="login-logo">
+                {% include "wagtailadmin/icons/wagtail.svg" %}
+            </div>
+        {% endblock %}
+
+        
+    </main>
+{% endblock %}

--- a/src/wagtail_2fa/views.py
+++ b/src/wagtail_2fa/views.py
@@ -31,7 +31,9 @@ from wagtail_2fa.mixins import OtpRequiredMixin
 
 class LoginView(RedirectURLMixin, FormView):
 
-    if WAGTAIL_VERSION >= (5, 0):
+    if WAGTAIL_VERSION >= (6, 0):
+        template_name = "wagtail_2fa/otp_form_v6.html"
+    elif WAGTAIL_VERSION < (6, 0) and WAGTAIL_VERSION >= (5, 0):
         template_name = "wagtail_2fa/otp_form.html"
     else:
         template_name = "wagtail_2fa/legacy/otp_form.html"

--- a/src/wagtail_2fa/wagtail_hooks.py
+++ b/src/wagtail_2fa/wagtail_hooks.py
@@ -9,6 +9,8 @@ from wagtail.users.widgets import UserListingButton
 
 from wagtail_2fa import views
 
+from wagtail import VERSION as WAGTAIL_VERSION
+
 
 @hooks.register("register_admin_urls")
 def urlpatterns():
@@ -68,14 +70,25 @@ def register(request):
     }
 
 
-@hooks.register("register_user_listing_buttons")
-def register_user_listing_buttons(context, user):
-    yield UserListingButton(
-        _("Manage 2FA"),
-        reverse("wagtail_2fa_device_list", kwargs={"user_id": user.id}),
-        attrs={"title": _("Edit this user")},
-        priority=100,
-    )
+if WAGTAIL_VERSION >= (6, 0):
+    @hooks.register("register_user_listing_buttons")
+    def register_user_listing_buttons(user, request_user):
+        yield UserListingButton(
+            _("Manage 2FA"),
+            reverse("wagtail_2fa_device_list", kwargs={"user_id": user.id}),
+            attrs={"title": _("Edit this user")},
+            priority=100,
+        )
+else:
+    @hooks.register("register_user_listing_buttons")
+    def register_user_listing_buttons(context, user):
+        yield UserListingButton(
+            _("Manage 2FA"),
+            reverse("wagtail_2fa_device_list", kwargs={"user_id": user.id}),
+            attrs={"title": _("Edit this user")},
+            priority=100,
+        )
+
 
 
 @hooks.register("register_permissions")


### PR DESCRIPTION
1. **Template fixes:** using `{% formattedfield %}` tag to replace direct use of wagtailadmin/shared/field.html to avoid TemplateSyntaxError in Wagtail 6+. Separate template created and conditionally checked.

2. **Logout loop fix:** added a button for signout button in the form with `formaction`/`formmethod` attributes to ensure logout is a POST with a proper `?next=/admin/login/`.

3. **Hook signature update:** `register_user_listing_buttons(user, request_user)` added conditionally for wagtail 6+