### PR TITLE
Resolving unamed url raised Resolver404 and prevent preview

### DIFF
--- a/src/wagtail_2fa/middleware.py
+++ b/src/wagtail_2fa/middleware.py
@@ -2,6 +2,7 @@ from functools import partial
 
 import django_otp
 from django.conf import settings
+from django.urls.exceptions import Resolver404
 from django.contrib.auth.views import redirect_to_login
 from django.urls import resolve, reverse
 from django.utils.functional import SimpleLazyObject
@@ -74,7 +75,11 @@ class VerifyUserMiddleware(_OTPMiddleware):
             return False
 
         # Don't require verification for specified URL names
-        request_url_name = resolve(request.path_info).url_name
+        try:
+            request_url_name = resolve(request.path_info).url_name
+        except Resolver404:
+            return False
+
         if request_url_name in self._allowed_url_names:
             return False
 


### PR DESCRIPTION
Hello!

In our setup, the resolver in the middleware couldn't resolve correclty the url "/":

```py
ipdb> request.path_info
'/'
ipdb> request
<WSGIRequest: GET '/'>
```
And so the `resolve(request.path_info)` lead to `Resolver404`, that breaks the middleware and the preview was always redirected to the home.

This PR fix it.

However, I did not understand why the middleware is having this request of path "/" , since I am in a preview.

