### PR TITLE
Custom 2FA permission for non-superusers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,18 @@
+Unreleased
+==================
+ - Add a narrower ``manage_2fa_devices`` permission so projects can grant
+   staff the ability to manage other users' 2FA devices without granting
+   the much broader ``change_user`` permission. Configurable via the new
+   ``WAGTAIL_2FA_MANAGE_DEVICES_PERMISSION`` setting (defaults to
+   ``wagtail_2fa.manage_2fa_devices``)
+ - Fix ``DeviceListView`` and ``DeviceDeleteView`` incorrectly checking a
+   hardcoded ``user.change_user`` permission (a leftover from the
+   package's sandbox project) instead of deriving the permission from the
+   consuming project's actual ``AUTH_USER_MODEL``
+ - The "Manage 2FA" user-listing button is now only shown to users who
+   are permitted to manage the target user's devices
+
+
 1.8.0 (2026-02-05)
 ==================
  - bump required version of django-otp and update middleware

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Unreleased
    staff the ability to manage other users' 2FA devices without granting
    the much broader ``change_user`` permission. Configurable via the new
    ``WAGTAIL_2FA_MANAGE_DEVICES_PERMISSION`` setting (defaults to
-   ``wagtail_2fa.manage_2fa_devices``)
+   ``wagtailadmin.manage_2fa_devices``).
  - Fix ``DeviceListView`` and ``DeviceDeleteView`` incorrectly checking a
    hardcoded ``user.change_user`` permission (a leftover from the
    package's sandbox project) instead of deriving the permission from the

--- a/src/wagtail_2fa/apps.py
+++ b/src/wagtail_2fa/apps.py
@@ -4,6 +4,7 @@ from django.conf import settings
 WAGTAIL_2FA_DEFAULT_SETTINGS = {
     "WAGTAIL_2FA_REQUIRED": False,
     "WAGTAIL_2FA_OTP_TOTP_NAME": False,
+    "WAGTAIL_2FA_MANAGE_DEVICES_PERMISSION": "wagtail_2fa.manage_2fa_devices",
 }
 
 

--- a/src/wagtail_2fa/apps.py
+++ b/src/wagtail_2fa/apps.py
@@ -4,7 +4,7 @@ from django.conf import settings
 WAGTAIL_2FA_DEFAULT_SETTINGS = {
     "WAGTAIL_2FA_REQUIRED": False,
     "WAGTAIL_2FA_OTP_TOTP_NAME": False,
-    "WAGTAIL_2FA_MANAGE_DEVICES_PERMISSION": "wagtail_2fa.manage_2fa_devices",
+    "WAGTAIL_2FA_MANAGE_DEVICES_PERMISSION": "wagtailadmin.manage_2fa_devices",
 }
 
 

--- a/src/wagtail_2fa/migrations/0002_manage_2fa_devices_permission.py
+++ b/src/wagtail_2fa/migrations/0002_manage_2fa_devices_permission.py
@@ -5,16 +5,16 @@ def create_manage_devices_permission(apps, schema_editor):
     ContentType = apps.get_model('contenttypes.ContentType')
     Permission = apps.get_model('auth.Permission')
 
-    wagtail_2fa_content_type, created = ContentType.objects.get_or_create(
-        app_label='wagtail_2fa',
-        model='wagtail2fa'
+    wagtailadmin_content_type, created = ContentType.objects.get_or_create(
+        app_label='wagtailadmin',
+        model='admin'
     )
 
     # A narrower permission than the stock change_user permission: lets a
     # user manage OTHER users' 2FA devices without granting general
     # user-editing rights (email, groups, is_superuser, is_active, etc).
     manage_devices_permission, created = Permission.objects.get_or_create(
-        content_type=wagtail_2fa_content_type,
+        content_type=wagtailadmin_content_type,
         codename='manage_2fa_devices',
         name='Can manage 2FA devices for other users'
     )
@@ -24,14 +24,14 @@ def remove_manage_devices_permission(apps, schema_editor):
     """Reverse the above addition of the permission."""
     ContentType = apps.get_model('contenttypes.ContentType')
     Permission = apps.get_model('auth.Permission')
-    wagtail_2fa_content_type = ContentType.objects.get(
-        app_label='wagtail_2fa',
-        model='wagtail2fa',
+    wagtailadmin_content_type = ContentType.objects.get(
+        app_label='wagtailadmin',
+        model='admin',
     )
 
     # This also removes the permission from all groups
     Permission.objects.filter(
-        content_type=wagtail_2fa_content_type,
+        content_type=wagtailadmin_content_type,
         codename='manage_2fa_devices',
     ).delete()
 

--- a/src/wagtail_2fa/migrations/0002_manage_2fa_devices_permission.py
+++ b/src/wagtail_2fa/migrations/0002_manage_2fa_devices_permission.py
@@ -1,0 +1,47 @@
+from django.db import migrations
+
+
+def create_manage_devices_permission(apps, schema_editor):
+    ContentType = apps.get_model('contenttypes.ContentType')
+    Permission = apps.get_model('auth.Permission')
+
+    wagtail_2fa_content_type, created = ContentType.objects.get_or_create(
+        app_label='wagtail_2fa',
+        model='wagtail2fa'
+    )
+
+    # A narrower permission than the stock change_user permission: lets a
+    # user manage OTHER users' 2FA devices without granting general
+    # user-editing rights (email, groups, is_superuser, is_active, etc).
+    manage_devices_permission, created = Permission.objects.get_or_create(
+        content_type=wagtail_2fa_content_type,
+        codename='manage_2fa_devices',
+        name='Can manage 2FA devices for other users'
+    )
+
+
+def remove_manage_devices_permission(apps, schema_editor):
+    """Reverse the above addition of the permission."""
+    ContentType = apps.get_model('contenttypes.ContentType')
+    Permission = apps.get_model('auth.Permission')
+    wagtail_2fa_content_type = ContentType.objects.get(
+        app_label='wagtail_2fa',
+        model='wagtail2fa',
+    )
+
+    # This also removes the permission from all groups
+    Permission.objects.filter(
+        content_type=wagtail_2fa_content_type,
+        codename='manage_2fa_devices',
+    ).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtail_2fa', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_manage_devices_permission, remove_manage_devices_permission),
+    ]

--- a/src/wagtail_2fa/utils.py
+++ b/src/wagtail_2fa/utils.py
@@ -15,7 +15,7 @@ def user_can_manage_other_users_devices(user):
     permission = getattr(
         settings,
         "WAGTAIL_2FA_MANAGE_DEVICES_PERMISSION",
-        "wagtail_2fa.manage_2fa_devices",
+        "wagtailadmin.manage_2fa_devices",
     )
     if permission and user.has_perm(permission):
         return True

--- a/src/wagtail_2fa/utils.py
+++ b/src/wagtail_2fa/utils.py
@@ -1,5 +1,27 @@
+from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_lazy as _
 from django_otp.plugins.otp_totp.models import TOTPDevice
+
+
+def user_can_manage_other_users_devices(user):
+    """
+    Whether `user` may create, view, or delete 2FA devices belonging to other users.
+
+    Checks the narrow, package-owned `manage_2fa_devices` permission first
+    (configurable via WAGTAIL_2FA_MANAGE_DEVICES_PERMISSION), then falls
+    back to the consuming project's own change_user permission.
+    """
+    permission = getattr(
+        settings,
+        "WAGTAIL_2FA_MANAGE_DEVICES_PERMISSION",
+        "wagtail_2fa.manage_2fa_devices",
+    )
+    if permission and user.has_perm(permission):
+        return True
+
+    User = get_user_model()
+    return user.has_perm(f"{User._meta.app_label}.change_{User._meta.model_name}")
 
 
 def get_unconfirmed_device(user):

--- a/src/wagtail_2fa/views.py
+++ b/src/wagtail_2fa/views.py
@@ -97,12 +97,14 @@ class DeviceListView(OtpRequiredMixin, ListView):
         """Override dispatch to ensure user is allowed to list the devices.
 
         Users are always allowed to list their own 2FA devices.
-        If they have the ``change_user`` permission, they are allowed
+        If they have the ``manage_2fa_devices`` permission (or the
+        consuming project's ``change_user`` permission), they are allowed
         to list other users' 2FA devices.
 
         """
-        if int(self.kwargs["user_id"]) == request.user.pk or request.user.has_perm(
-            "user.change_user"
+        user_id = int(self.kwargs["user_id"])
+        if user_id == request.user.pk or utils.user_can_manage_other_users_devices(
+            request.user
         ):
             if not self.user_allowed(request.user):
                 return self.handle_no_permission(request)
@@ -180,12 +182,13 @@ class DeviceDeleteView(OtpRequiredMixin, DeleteView):
         """Override dispatch to ensure user is allowed to delete the device.
 
         Users are always allowed to delete their own 2FA devices.
-        If they have the ``change_user`` permission, they are allowed
+        If they have the ``manage_2fa_devices`` permission (or the
+        consuming project's ``change_user`` permission), they are allowed
         to delete other users' 2FA devices.
         """
         device = TOTPDevice.objects.get(**self.kwargs)
-        if device.user.pk == request.user.pk or request.user.has_perm(
-            "user.change_user"
+        if device.user.pk == request.user.pk or utils.user_can_manage_other_users_devices(
+            request.user
         ):
             if not self.user_allowed(request.user):
                 return self.handle_no_permission(request)

--- a/src/wagtail_2fa/wagtail_hooks.py
+++ b/src/wagtail_2fa/wagtail_hooks.py
@@ -97,7 +97,7 @@ def register_2fa_permission():
     # Always registered, regardless of which VerifyUser*Middleware is in
     # use - this is a Wagtail Group-management permission.
     permissions |= Permission.objects.filter(
-        content_type__app_label="wagtail_2fa", codename="manage_2fa_devices"
+        content_type__app_label="wagtailadmin", codename="manage_2fa_devices"
     )
 
     return permissions

--- a/src/wagtail_2fa/wagtail_hooks.py
+++ b/src/wagtail_2fa/wagtail_hooks.py
@@ -3,13 +3,15 @@ from django.contrib.auth.models import Permission
 from django.urls import path, re_path, reverse
 from django.utils.translation import gettext_lazy as _
 
-from wagtail import hooks
+from wagtail import hooks, VERSION as WAGTAIL_VERSION
 from wagtail.admin.menu import MenuItem
-from wagtail.users.widgets import UserListingButton
 
-from wagtail_2fa import views
+if WAGTAIL_VERSION >= (7, 1):
+    from wagtail.admin.widgets import Button
+else:
+    from wagtail.users.widgets import UserListingButton as Button
 
-from wagtail import VERSION as WAGTAIL_VERSION
+from wagtail_2fa import utils, views
 
 
 @hooks.register("register_admin_urls")
@@ -70,32 +72,32 @@ def register(request):
     }
 
 
-if WAGTAIL_VERSION >= (6, 0):
-    @hooks.register("register_user_listing_buttons")
-    def register_user_listing_buttons(user, request_user):
-        yield UserListingButton(
+@hooks.register("register_user_listing_buttons")
+def register_user_listing_buttons(user, request_user):
+    if user.pk == request_user.pk or utils.user_can_manage_other_users_devices(
+        request_user
+    ):
+        yield Button(
             _("Manage 2FA"),
             reverse("wagtail_2fa_device_list", kwargs={"user_id": user.id}),
             attrs={"title": _("Edit this user")},
             priority=100,
         )
-else:
-    @hooks.register("register_user_listing_buttons")
-    def register_user_listing_buttons(context, user):
-        yield UserListingButton(
-            _("Manage 2FA"),
-            reverse("wagtail_2fa_device_list", kwargs={"user_id": user.id}),
-            attrs={"title": _("Edit this user")},
-            priority=100,
-        )
-
 
 
 @hooks.register("register_permissions")
 def register_2fa_permission():
+    permissions = Permission.objects.none()
+
     if "wagtail_2fa.middleware.VerifyUserPermissionsMiddleware" in settings.MIDDLEWARE:
-        return Permission.objects.filter(
+        permissions |= Permission.objects.filter(
             content_type__app_label="wagtailadmin", codename="enable_2fa"
         )
 
-    return Permission.objects.none()
+    # Always registered, regardless of which VerifyUser*Middleware is in
+    # use - this is a Wagtail Group-management permission.
+    permissions |= Permission.objects.filter(
+        content_type__app_label="wagtail_2fa", codename="manage_2fa_devices"
+    )
+
+    return permissions

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.core.exceptions import PermissionDenied
 from django.http.response import Http404
 from django.test import override_settings
@@ -143,13 +144,19 @@ def test_delete_user_device_unauthorized(client, user, monkeypatch):
 
 class TestViewsChangeUserPermission:
     """Test suite which ensures that:
-    - users without the change_user permission cannot manage other users' 2FA devices
+    - users without the manage_2fa_devices/change_user permission cannot
+      manage other users' 2FA devices
+    - users with either permission can manage other users' 2FA devices
     - users can manage their own devices
     """
 
-    def test_verified_user_has_no_change_user_perm(self, verified_user):
-        """Sanity check."""
-        assert not verified_user.has_perm("user.change_user")
+    def test_verified_user_has_no_manage_devices_or_change_user_perm(self, verified_user):
+        """Sanity check - a freshly-created user has no special permissions."""
+        assert not verified_user.has_perm("wagtail_2fa.manage_2fa_devices")
+        # The consuming project's actual user model app_label/name here is
+        # auth.User, since these tests don't configure a custom
+        # AUTH_USER_MODEL - see conftest.py's settings.configure().
+        assert not verified_user.has_perm("auth.change_user")
 
     def test_device_list_view_for_own_user_returns_200(self, verified_user, rf):
         with override_settings(WAGTAIL_2FA_REQUIRED=True):
@@ -194,6 +201,73 @@ class TestViewsChangeUserPermission:
 
             with pytest.raises(PermissionDenied):
                 DeviceDeleteView.as_view()(request, pk=other_device.id)
+
+    def test_device_list_view_for_other_user_allowed_with_manage_2fa_devices_perm(
+        self, user, verified_user, rf
+    ):
+        """The narrow manage_2fa_devices permission is enough on its own -
+        no change_user permission required."""
+        permission = Permission.objects.get(
+            content_type__app_label="wagtail_2fa", codename="manage_2fa_devices"
+        )
+        verified_user.user_permissions.add(permission)
+        # has_perm caches permissions on the instance; clear just that
+        # cache rather than refetching the user, which would lose the
+        # is_verified method django_otp's middleware attached to this
+        # specific instance in the verified_user fixture.
+        for cache_attr in ("_perm_cache", "_user_perm_cache", "_group_perm_cache"):
+            if hasattr(verified_user, cache_attr):
+                delattr(verified_user, cache_attr)
+
+        with override_settings(WAGTAIL_2FA_REQUIRED=True):
+            request = rf.get("foo")
+            request.user = verified_user
+
+            response = DeviceListView.as_view()(request, user_id=user.id)
+            assert response.status_code == 200
+
+    def test_device_delete_view_for_other_user_allowed_with_manage_2fa_devices_perm(
+        self, user, verified_user, rf
+    ):
+        permission = Permission.objects.get(
+            content_type__app_label="wagtail_2fa", codename="manage_2fa_devices"
+        )
+        verified_user.user_permissions.add(permission)
+        for cache_attr in ("_perm_cache", "_user_perm_cache", "_group_perm_cache"):
+            if hasattr(verified_user, cache_attr):
+                delattr(verified_user, cache_attr)
+
+        with override_settings(WAGTAIL_2FA_REQUIRED=True):
+            other_device = TOTPDevice.objects.create(
+                name="Initial", user=user, confirmed=True
+            )
+            request = rf.get("foo")
+            request.user = verified_user
+
+            response = DeviceDeleteView.as_view()(request, pk=other_device.id)
+            assert response.status_code == 200
+
+    def test_device_list_view_for_other_user_allowed_with_change_user_perm(
+        self, user, verified_user, rf
+    ):
+        """The broad change_user permission still works too (e.g. for
+        existing superusers/admins who already hold it), derived
+        dynamically from AUTH_USER_MODEL rather than the old hardcoded
+        "user.change_user" string that could never match a real project."""
+        permission = Permission.objects.get(
+            content_type__app_label="auth", codename="change_user"
+        )
+        verified_user.user_permissions.add(permission)
+        for cache_attr in ("_perm_cache", "_user_perm_cache", "_group_perm_cache"):
+            if hasattr(verified_user, cache_attr):
+                delattr(verified_user, cache_attr)
+
+        with override_settings(WAGTAIL_2FA_REQUIRED=True):
+            request = rf.get("foo")
+            request.user = verified_user
+
+            response = DeviceListView.as_view()(request, user_id=user.id)
+            assert response.status_code == 200
 
     def test_device_update_view_for_own_user_returns_200(self, verified_user, rf):
         with override_settings(WAGTAIL_2FA_REQUIRED=True):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -152,7 +152,7 @@ class TestViewsChangeUserPermission:
 
     def test_verified_user_has_no_manage_devices_or_change_user_perm(self, verified_user):
         """Sanity check - a freshly-created user has no special permissions."""
-        assert not verified_user.has_perm("wagtail_2fa.manage_2fa_devices")
+        assert not verified_user.has_perm("wagtailadmin.manage_2fa_devices")
         # The consuming project's actual user model app_label/name here is
         # auth.User, since these tests don't configure a custom
         # AUTH_USER_MODEL - see conftest.py's settings.configure().
@@ -208,7 +208,7 @@ class TestViewsChangeUserPermission:
         """The narrow manage_2fa_devices permission is enough on its own -
         no change_user permission required."""
         permission = Permission.objects.get(
-            content_type__app_label="wagtail_2fa", codename="manage_2fa_devices"
+            content_type__app_label="wagtailadmin", codename="manage_2fa_devices"
         )
         verified_user.user_permissions.add(permission)
         # has_perm caches permissions on the instance; clear just that
@@ -230,7 +230,7 @@ class TestViewsChangeUserPermission:
         self, user, verified_user, rf
     ):
         permission = Permission.objects.get(
-            content_type__app_label="wagtail_2fa", codename="manage_2fa_devices"
+            content_type__app_label="wagtailadmin", codename="manage_2fa_devices"
         )
         verified_user.user_permissions.add(permission)
         for cache_attr in ("_perm_cache", "_user_perm_cache", "_group_perm_cache"):


### PR DESCRIPTION
  - A project we're working on wanted some of their user groups to be able to manage other users' 2FA devices without granting full superuser access. This adds a narrower `manage_2fa_devices` permission
  (configurable via the new `WAGTAIL_2FA_MANAGE_DEVICES_PERMISSION` setting).
  - Removes the hard-coded check against the built-in User model's `change_user` permission. Permission checks now derive from the project's actual `AUTH_USER_MODEL`, so this works correctly for projects using a
  custom user model.